### PR TITLE
add maintainence banner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,3 +57,8 @@ FROM_EMAIL="noreply@yourdomain.com"
 # For local testing
 AWS_ACCESS_KEY_ID="your-aws-access-key-id" 
 AWS_SECRET_ACCESS_KEY="your-aws-secret-access-key"
+
+# URL of base URL
+NEXT_PUBLIC_BASE_URL=
+# Maintenance Banner Configuration
+NEXT_PUBLIC_MAINTAINENCE_MSG=🚧 Our services will be down for maintenance from 2:00 AM to 4:00 AM KST on January 15th for system upgrades. We apologize for any inconvenience.

--- a/app/components/MaintenanceBanner.tsx
+++ b/app/components/MaintenanceBanner.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+
+export default function MaintenanceBanner() {
+  const rawMessage = useMemo(() => process.env.NEXT_PUBLIC_MAINTAINENCE_MSG || "", []);
+  const [visible, setVisible] = useState(false);
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const message = (rawMessage || "").trim();
+    const hasMessage = Boolean(message);
+    setVisible(hasMessage);
+  }, [rawMessage]);
+
+  useEffect(() => {
+    const banner = ref.current;
+    const updateHeightVar = () => {
+      const height = banner ? Math.ceil(banner.getBoundingClientRect().height) : 0;
+      document.documentElement.style.setProperty("--maintenance-banner-height", `${height}px`);
+    };
+
+    updateHeightVar();
+    window.addEventListener("resize", updateHeightVar);
+    return () => {
+      window.removeEventListener("resize", updateHeightVar);
+      document.documentElement.style.removeProperty("--maintenance-banner-height");
+    };
+  }, [visible]);
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <>
+      <div
+        ref={ref}
+        className="fixed top-0 w-screen z-[60]"
+      >
+        <div className="w-full bg-amber-500 text-white">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2 text-center text-sm font-medium">
+            {rawMessage}
+          </div>
+        </div>
+      </div>
+      {/* Spacer to push the content below the fixed banner. */}
+      <div aria-hidden="true" style={{ height: "var(--maintenance-banner-height, 0px)" }} />
+    </>
+  );
+}
+
+

--- a/app/components/NavBar.tsx
+++ b/app/components/NavBar.tsx
@@ -91,7 +91,7 @@ export default function NavBar() {
   // Prevent hydration mismatch by not rendering anything until mounted
   if (!mounted) {
     return (
-      <nav className="bg-gradient-to-r from-gray-800 via-gray-900 to-gray-800 shadow-lg fixed top-0 w-screen z-50">
+      <nav className="bg-gradient-to-r from-gray-800 via-gray-900 to-gray-800 shadow-lg fixed w-screen z-50" style={{ top: "var(--maintenance-banner-height, 0px)" }}>
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="h-16 flex items-center justify-between">
             {/* Logo Section */}
@@ -112,7 +112,7 @@ export default function NavBar() {
   }
 
   return (
-    <nav className="bg-gradient-to-r from-gray-800 via-gray-900 to-gray-800 shadow-lg fixed top-0 w-screen z-50">
+    <nav className="bg-gradient-to-r from-gray-800 via-gray-900 to-gray-800 shadow-lg fixed w-screen z-50" style={{ top: "var(--maintenance-banner-height, 0px)" }}>
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="h-16 flex items-center justify-between">
           {/* Logo Section */}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@
 
 import "./globals.css";
 import NavBar from "./components/NavBar";
+import MaintenanceBanner from "./components/MaintenanceBanner";
 import { SessionProvider } from "next-auth/react";
 
 export default function RootLayout({
@@ -13,6 +14,7 @@ export default function RootLayout({
     <html lang="en">
       <body className={`antialiased w-screen`}>
         <SessionProvider>
+          <MaintenanceBanner />
           <NavBar />
           {children}
         </SessionProvider>


### PR DESCRIPTION
## Description:
- add maintenance banner
- set maintenance based on the `NEXT_PUBLIC_MAINTAINENCE_MSG` variable in .env
## Changes:
-
## Test Scope / Change Impact :
-
## Related Documentation Link (optional)
-
## Screenshots (optional)
<img width="470" height="577" alt="Screenshot 2025-09-19 at 3 39 27 PM" src="https://github.com/user-attachments/assets/8ffd46a9-b940-47ef-8f5a-50f463425d44" />
<img width="551" height="293" alt="Screenshot 2025-09-19 at 3 39 37 PM" src="https://github.com/user-attachments/assets/fe143d84-ea54-47fd-9364-05b2184fc1ae" />
