### PR TITLE
Add rate limits to balance API endpoints

### DIFF
--- a/backend/routes/balance.js
+++ b/backend/routes/balance.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const v2Router = express.Router();
 const { ethers } = require('ethers');
 const { prisma } = require('../utils/prisma');
+const { publicWriteRateLimit } = require('../middleware/feeDelegationRateLimit');
 const { createResponse, isEnoughBalance, checkWhitelistedAndGetDapp, getDappByApiKey } = require('../utils/apiUtils');
 const { formatKaia } = require('@kaiachain/ethers-ext/v6');
 
@@ -192,7 +193,7 @@ router.options('/', async (req, res) => {
  *               status: false
  */
 // GET /api/balance
-router.get('/', async (req, res) => {
+router.get('/', publicWriteRateLimit('balance'), async (req, res) => {
   try {
     const result = await resolveDappBalance(req, res);
     if (!result) return;
@@ -349,7 +350,7 @@ v2Router.options('/', async (req, res) => {
 });
 
 // GET /api/v2/balance
-v2Router.get('/', async (req, res) => {
+v2Router.get('/', publicWriteRateLimit('balanceV2'), async (req, res) => {
   try {
     const result = await resolveDappBalance(req, res);
     if (!result) return;

--- a/backend/test/rateLimitPublicWrites.test.js
+++ b/backend/test/rateLimitPublicWrites.test.js
@@ -5,15 +5,24 @@ const LOW_IP_MAX = '3';
 const LOW_API_KEY_MAX = '2';
 const WINDOW_MS = '60000';
 
-async function burstPost(agent, path, count, opts = {}) {
+async function burstRequest(agent, method, path, count, opts = {}) {
   const responses = [];
   for (let i = 0; i < count; i++) {
-    let req = agent.post(path).send(opts.body ?? {});
+    let req = agent[method](path);
+    if (method === 'post') req = req.send(opts.body ?? {});
     if (opts.ip) req = req.set('X-Forwarded-For', opts.ip);
     if (opts.authorization) req = req.set('Authorization', opts.authorization);
     responses.push(await req);
   }
   return responses;
+}
+
+async function burstPost(agent, path, count, opts = {}) {
+  return burstRequest(agent, 'post', path, count, opts);
+}
+
+async function burstGet(agent, path, count, opts = {}) {
+  return burstRequest(agent, 'get', path, count, opts);
 }
 
 describe('public write rate limits', () => {
@@ -89,6 +98,51 @@ describe('public write rate limits', () => {
 
       const responses = await burstPost(agent, '/api/gasFreeSwapKaia', burstCount, {
         ip: '203.0.113.31',
+        authorization: auth,
+      });
+
+      const limited = responses.filter((r) => r.status === 429);
+      expect(limited.length).toBeGreaterThanOrEqual(1);
+      expect(limited[0].body.error).toBe('RATE_LIMITED');
+    });
+  });
+
+  it('GET /api/balance returns 429 with Retry-After when IP burst exceeds limit', async () => {
+    await withEnv(rateLimitEnv, async () => {
+      const agent = createTestAgent();
+      const responses = await burstGet(agent, '/api/balance', Number(LOW_IP_MAX) + 1, {
+        ip: '203.0.113.40',
+      });
+
+      const limited = responses.filter((r) => r.status === 429);
+      expect(limited.length).toBeGreaterThanOrEqual(1);
+      expect(limited[0].body.error).toBe('RATE_LIMITED');
+      expect(limited[0].headers['retry-after']).toBeDefined();
+    });
+  });
+
+  it('GET /api/v2/balance returns 429 with Retry-After when IP burst exceeds limit', async () => {
+    await withEnv(rateLimitEnv, async () => {
+      const agent = createTestAgent();
+      const responses = await burstGet(agent, '/api/v2/balance', Number(LOW_IP_MAX) + 1, {
+        ip: '203.0.113.41',
+      });
+
+      const limited = responses.filter((r) => r.status === 429);
+      expect(limited.length).toBeGreaterThanOrEqual(1);
+      expect(limited[0].body.error).toBe('RATE_LIMITED');
+      expect(limited[0].headers['retry-after']).toBeDefined();
+    });
+  });
+
+  it('limits apply per API key when Bearer token present on balance', async () => {
+    await withEnv(rateLimitEnv, async () => {
+      const agent = createTestAgent();
+      const burstCount = Number(LOW_API_KEY_MAX) + 1;
+      const auth = 'Bearer balance-api-key-for-rate-limit';
+
+      const responses = await burstGet(agent, '/api/balance', burstCount, {
+        ip: '203.0.113.42',
         authorization: auth,
       });
 


### PR DESCRIPTION
## Summary
- Apply the same `publicWriteRateLimit` middleware used by `signAsFeePayer` and `gasFreeSwapKaia` to `GET /api/balance` and `GET /api/v2/balance`
- Cover IP burst and Bearer API-key limiting with new tests in `rateLimitPublicWrites.test.js`

## Test plan
- [ ] `npm test -- --testPathPattern=rateLimitPublicWrites --watchman=false`
- [ ] Confirm bursting `GET /api/balance` and `GET /api/v2/balance` returns `429` / `RATE_LIMITED` with `Retry-After`
- [ ] Confirm Bearer-authenticated balance requests are limited per API key independently of IP