### PR TITLE
fix(ci): stop baking RECAPTCHA_SECRET_KEY into the image and logging .env

### DIFF
--- a/.github/workflows/ci-kairos-gcp.yaml
+++ b/.github/workflows/ci-kairos-gcp.yaml
@@ -49,12 +49,12 @@ jobs:
             IMAGE_TAG: ${{ steps.vars.outputs.hash }}
             API_URL: ${{ vars.KAIROS_API_URL_GCP }}
             NEXT_PUBLIC_RECAPTCHA_SITE_KEY: ${{ secrets.NEXT_PUBLIC_RECAPTCHA_SITE_KEY_GCP }}
-            RECAPTCHA_SECRET_KEY: ${{ secrets.RECAPTCHA_SECRET_KEY_GCP }}
         run: |
+            # Only build-time NEXT_PUBLIC_* values go into the image. Runtime
+            # secrets (RECAPTCHA_SECRET_KEY etc.) are injected by ESO from GSM
+            # (fee-delegation-server-dev) — never bake them into image layers.
             echo "NEXT_PUBLIC_API_URL= $API_URL" > .env.production
             echo "NEXT_PUBLIC_RECAPTCHA_SITE_KEY=$NEXT_PUBLIC_RECAPTCHA_SITE_KEY" >> .env.production
-            echo "RECAPTCHA_SECRET_KEY=$RECAPTCHA_SECRET_KEY" >> .env.production
-            cat .env.production
             docker build  -f dockerfile --build-arg VERSION=$IMAGE_TAG -t ${{ env.AR_URL }}/fee-delegation-server:$IMAGE_TAG .
             docker push ${{ env.AR_URL }}/fee-delegation-server:$IMAGE_TAG
             docker tag ${{ env.AR_URL }}/fee-delegation-server:$IMAGE_TAG ${{ env.AR_URL }}/fee-delegation-server:latest

--- a/.github/workflows/ci-mainnet-gcp.yml
+++ b/.github/workflows/ci-mainnet-gcp.yml
@@ -49,12 +49,12 @@ jobs:
             IMAGE_TAG: ${{ steps.vars.outputs.hash }}
             API_URL: ${{ vars.MAINNET_API_URL_GCP }}
             NEXT_PUBLIC_RECAPTCHA_SITE_KEY: ${{ secrets.NEXT_PUBLIC_RECAPTCHA_SITE_KEY_GCP }}
-            RECAPTCHA_SECRET_KEY: ${{ secrets.RECAPTCHA_SECRET_KEY_GCP }}
         run: |
+            # Only build-time NEXT_PUBLIC_* values go into the image. Runtime
+            # secrets (RECAPTCHA_SECRET_KEY etc.) are injected by ESO from GSM
+            # (prod-fee-delegation-server) — never bake them into image layers.
             echo "NEXT_PUBLIC_API_URL= $API_URL" > .env.production
             echo "NEXT_PUBLIC_RECAPTCHA_SITE_KEY=$NEXT_PUBLIC_RECAPTCHA_SITE_KEY" >> .env.production
-            echo "RECAPTCHA_SECRET_KEY=$RECAPTCHA_SECRET_KEY" >> .env.production
-            cat .env.production
             docker build  -f dockerfile --build-arg VERSION=$IMAGE_TAG -t ${{ env.AR_URL }}/fee-delegation-server:$IMAGE_TAG .
             docker push ${{ env.AR_URL }}/fee-delegation-server:$IMAGE_TAG
             docker tag ${{ env.AR_URL }}/fee-delegation-server:$IMAGE_TAG ${{ env.AR_URL }}/fee-delegation-server:latest


### PR DESCRIPTION
## Problem (P0)

Both GCP build workflows write `RECAPTCHA_SECRET_KEY` into `.env.production`, print the file with `cat`, and bake it into the Docker image. Anyone with Artifact Registry **pull** access can extract it from image layers, and rotation would require an image rebuild. This violates the Secret Management Policy (DEVOPS-393, T2 = runtime injection via GSM+ESO).

## Fix

- Remove `RECAPTCHA_SECRET_KEY` from `.env.production` (both kairos/mainnet workflows)
- Remove the `cat .env.production` log step
- Keep build-time `NEXT_PUBLIC_*` values (inlined into the client bundle — public by nature)

## Safety verification (done before this PR)

- ESO wiring confirmed in argocd-apps: `ExternalSecret` (`dataFrom: extract`) + deployment `envFrom: secretRef` for both envs
- GSM secrets `fee-delegation-server-dev` / `prod-fee-delegation-server` **already contain** `RECAPTCHA_SECRET_KEY` (key names verified, values untouched)
- Next.js: container env takes precedence over `.env.production`, so the runtime value is already the ESO one

## Follow-up (owner)

- [ ] **Rotate `RECAPTCHA_SECRET_KEY`** after merge (previous images contain it — DEVOPS-393 §6, GSM value + reCAPTCHA console)
- [ ] The now-unused GH secret `RECAPTCHA_SECRET_KEY_GCP` can be deleted

Found during the org-wide CI/CD standard review (Kaia CI/CD Standard v0.2, BP 5.7). Separate P2 follow-ups (checkout@v3, set-output, PR CI) will come with standard onboarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)